### PR TITLE
add branch name to sonar-scanner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ android:
 script:
     - ./gradlew build
     - ./gradlew test
-    - ./gradlew sonarqube -Dsonar.organization=hypeo -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN
+    - ./gradlew sonarqube -Dsonar.organization=hypeo -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN -Dsonar.branch.name=$TRAVIS_BRANCH


### PR DESCRIPTION
added branch name to sonar-scanner such that sonarcloud displays seperate quality gates for every branch.